### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
 ]
 dependencies = [
-    "ipyautoui>=0.7",
+    "ipyautoui==0.7.1",
     "pydantic>2",
     "Jinja2",
     "halo",


### PR DESCRIPTION
QUICKFIX

pin to version of ipyautoui I know is working...
this happened because `Dictionary` was removed from the `ipyautoui.custom` namespace (which probs shouldn't have happened). If this repo continues we can look at this more.